### PR TITLE
Sort patches in the right order

### DIFF
--- a/gh-mail-pr.py
+++ b/gh-mail-pr.py
@@ -42,7 +42,7 @@ def fix_patch(f, hdr, i, tlen):
 def fix_headers(hdr):
 
 	print "Fix hdr with hdr %s\n" % hdr
-	pfiles = glob.glob("./to_send-p*.patch")
+	pfiles = sorted(glob.glob("./to_send-p*.patch"))
 	i = 0
 	for f in pfiles:
 		i = i + 1


### PR DESCRIPTION
glob.glob() uses 'native' sorting order. Sort the list according to the file name. For the reference see https://stackoverflow.com/questions/6773584/how-is-pythons-glob-glob-ordered