### PR TITLE
Do not eat non-PATCH tags when updating version

### DIFF
--- a/gh-hook-mr.py
+++ b/gh-hook-mr.py
@@ -93,7 +93,7 @@ for m in re.finditer(r'\[PATCH.*v([0-9]+)\]', title):
 
 version += 1
 
-m = re.search(r"\[PATCH.*\] (.*)", title)
+m = re.search(r"\[PATCH.*?\] (.*)", title)
 if m:
 	title = m.group(1)
 


### PR DESCRIPTION
Use non-greedy pattern matching to allow PR tags like [RFC], [WIP], etc to survive after version update.