### PR TITLE
Dockerfile: set noninteractive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 RUN apt-get update \
-    && apt-get install -yy \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 	git \
 	git-email \
 	nginx \


### PR DESCRIPTION
If noninteractive is not set, the dockerfile will get stuck on postfix
or other related options.